### PR TITLE
remove broken waffle.io link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-[![Stories in Ready](https://badge.waffle.io/arc42/docs.arc42.org-site.png?label=ready&title=Ready)](https://waffle.io/arc42/docs.arc42.org-site)
 # arc42 Documentation, help and tips
 
 Here we collect tips on using arc42.


### PR DESCRIPTION
As waffle.io is down, we might as well remove the broken link :)